### PR TITLE
Switch Date and Expiry headers to GMT as per standard

### DIFF
--- a/packages/core/lib/http.js
+++ b/packages/core/lib/http.js
@@ -27,7 +27,7 @@ export const addHeaderToRequest = (request, key, value) => {
 export const isResponse = (response) => response instanceof Response
 export const newResponse = ({ status, url, body }, headersObj) => {
   const headers = headersGetAll(headersObj)
-  headers.date ??= new Date().toString()
+  headers.date ??= new Date().toUTCString()
   const response = new Response(body, { status, headers })
   Object.defineProperty(response, 'url', { value: url })
   return response

--- a/packages/core/lib/strategies.js
+++ b/packages/core/lib/strategies.js
@@ -63,7 +63,7 @@ export const strategyNetworkFirst = async (request, event, config) => {
       response = addHeaderToResponse(
         response,
         'Expires',
-        new Date(responseTime + maxAge * 1000).toString()
+        new Date(responseTime + maxAge * 1000).toUTCString()
       )
 
       event.waitUntil(cachePut(config.cacheKey, request, response.clone()))
@@ -119,7 +119,7 @@ export const strategyStatic = (response) => {
   const pathname = new URL(request.url).pathname.split('/')
   const filename = pathname[pathname.length - 1]
   return newResponse({status:201, body:request.body},{
-      Date: new Date().toString(),
+      Date: new Date().toUTCString(),
       'Content-Type': request.headers.get('Content-Type'),
       'Content-Disposition': `attachment; filename="${filename}"`
     })
@@ -135,7 +135,7 @@ export const strategyStatic = (response) => {
   return newResponse(body, {
     status: 201,
     headers: new Headers({
-      Date: new Date().toString(),
+      Date: new Date().toUTCString(),
       'Content-Type': contentType,
       'Content-Disposition': `attachment;filename="${filename}"`
     })

--- a/test-unit/helper.js
+++ b/test-unit/helper.js
@@ -28,7 +28,7 @@ const mockResponses = {
       headers: new Headers({
         'Content-Type': 'application/json; charset=UTF-8',
         'Cache-Control': 'max-age=86400',
-        Date: new Date().toString()
+        Date: new Date().toUTCString()
       })
     }),
   [`${domain}/403`]: () =>
@@ -45,7 +45,7 @@ const mockResponses = {
       headers: new Headers({
         'Content-Type': 'application/json; charset=UTF-8',
         'Cache-Control': 'max-age=86400',
-        Date: new Date().toString()
+        Date: new Date().toUTCString()
       })
     }),
 
@@ -59,7 +59,7 @@ const mockResponses = {
       headers: new Headers({
         'Content-Type': 'application/json; charset=UTF-8',
         'Cache-Control': 'max-age=86400',
-        Date: new Date().toString()
+        Date: new Date().toUTCString()
       })
     }),
   [`${domain}/cache-control/no-cache`]: () =>
@@ -69,7 +69,7 @@ const mockResponses = {
       headers: new Headers({
         'Content-Type': 'application/json; charset=UTF-8',
         'Cache-Control': 'no-cache',
-        Date: new Date().toString()
+        Date: new Date().toUTCString()
       })
     }),
   [`${domain}/cache-control/max-age=0`]: () =>
@@ -79,7 +79,7 @@ const mockResponses = {
       headers: new Headers({
         'Content-Type': 'application/json; charset=UTF-8',
         'Cache-Control': 'max-age=0',
-        Date: new Date().toString()
+        Date: new Date().toUTCString()
       })
     }),
   [`${domain}/cache-control/null`]: () =>
@@ -88,7 +88,7 @@ const mockResponses = {
       statusText: 'OK',
       headers: new Headers({
         'Content-Type': 'application/json; charset=UTF-8',
-        Date: new Date().toString()
+        Date: new Date().toUTCString()
       })
     }),
 
@@ -99,8 +99,8 @@ const mockResponses = {
       headers: new Headers({
         'Content-Type': 'application/json; charset=UTF-8',
         'Cache-Control': 'max-age=86400',
-        Date: new Date().toString(),
-        Expires: (Date.now() + 86400 * 1000).toString()
+        Date: new Date().toUTCString(),
+        Expires: new Date(Date.now() + 86400 * 1000).toUTCString()
       })
     }),
   [`${domain}/cache/expired`]: () =>
@@ -110,7 +110,7 @@ const mockResponses = {
       headers: new Headers({
         'Content-Type': 'application/json; charset=UTF-8',
         'Cache-Control': 'max-age=86400',
-        Date: new Date(Date.now() - 86400 * 1000).toString(),
+        Date: new Date(Date.now() - 86400 * 1000).toUTCString(),
         Expires: new Date(Date.now() - 86400 * 1000).toString()
       })
     }),
@@ -121,7 +121,7 @@ const mockResponses = {
       statusText: 'OK',
       headers: new Headers({
         'Content-Type': 'application/json; charset=UTF-8',
-        Date: new Date().toString()
+        Date: new Date().toUTCString()
       })
     }),
   [`${domain}/main`]: () =>
@@ -130,7 +130,7 @@ const mockResponses = {
       statusText: 'OK',
       headers: new Headers({
         'Content-Type': 'application/json; charset=UTF-8',
-        Date: new Date().toString()
+        Date: new Date().toUTCString()
       })
     }),
   [`${domain}/footer`]: () =>
@@ -139,7 +139,7 @@ const mockResponses = {
       statusText: 'OK',
       headers: new Headers({
         'Content-Type': 'application/json; charset=UTF-8',
-        Date: new Date().toString()
+        Date: new Date().toUTCString()
       })
     })
 }

--- a/test-unit/helper.js
+++ b/test-unit/helper.js
@@ -111,7 +111,7 @@ const mockResponses = {
         'Content-Type': 'application/json; charset=UTF-8',
         'Cache-Control': 'max-age=86400',
         Date: new Date(Date.now() - 86400 * 1000).toUTCString(),
-        Expires: new Date(Date.now() - 86400 * 1000).toString()
+        Expires: new Date(Date.now() - 86400 * 1000).toUTCString()
       })
     }),
   [`${domain}/cache/notfound`]: () => undefined,


### PR DESCRIPTION
According to the docs, dates in HTTP headers should be in GMT instead of local time.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Expires#gmt
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Date#gmt

