### PR TITLE
chore: update type tests

### DIFF
--- a/.github/workflows/test-types.yml
+++ b/.github/workflows/test-types.yml
@@ -1,0 +1,30 @@
+name: Tests (types)
+
+on:
+  pull_request:
+
+env:
+  NODE_VERSION: 24.x
+
+permissions:
+  contents: read
+
+jobs:
+  types:
+    name: Tests (types)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org
+      - name: Install dependencies
+        run: |
+          npm ci --ignore-scripts
+      - name: Type tests
+        run: |
+          npm run test:types

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
 				"@commitlint/cli": "^20.0.0",
 				"@commitlint/config-conventional": "^20.0.0",
 				"@playwright/test": "^1.27.0",
-				"@tsconfig/node24": "^24.0.0",
 				"esbuild": "^0.27.0",
 				"fake-indexeddb": "^4.0.0",
 				"fast-check": "^4.0.0",
@@ -2438,13 +2437,6 @@
 				"svelte": "^5.0.0",
 				"vite": "^6.3.0 || ^7.0.0"
 			}
-		},
-		"node_modules/@tsconfig/node24": {
-			"version": "24.0.4",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node24/-/node24-24.0.4.tgz",
-			"integrity": "sha512-2A933l5P5oCbv6qSxHs7ckKwobs8BDAe9SJ/Xr2Hy+nDlwmLE1GhFh/g/vXGRZWgxBg9nX/5piDtHR9Dkw/XuA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@types/cookie": {
 			"version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
 		"@commitlint/cli": "^20.0.0",
 		"@commitlint/config-conventional": "^20.0.0",
 		"@playwright/test": "^1.27.0",
-		"@tsconfig/node24": "^24.0.0",
 		"esbuild": "^0.27.0",
 		"fake-indexeddb": "^4.0.0",
 		"fast-check": "^4.0.0",

--- a/packages/cache-control/index.tst.ts
+++ b/packages/cache-control/index.tst.ts
@@ -1,31 +1,22 @@
 /// <reference lib="webworker" />
 
 import cacheControl from "@work-bee/cache-control";
+import type { AfterMiddleware } from "@work-bee/core";
 import { describe, expect, test } from "tstyche";
-
-/** @typedef {import("@work-bee/core").AfterMiddleware} AfterMiddleware */
 
 describe("cache-control", () => {
 	test("returns CacheControlMiddlewareResult", () => {
 		const result = cacheControl({ cacheControl: "max-age=3600" });
-		expect(result).type.toBe(
-			/** @type {{ afterNetwork: AfterMiddleware }} */ (
-				/** @type {unknown} */ (undefined)
-			),
-		);
+		expect(result).type.toBe<{ afterNetwork: AfterMiddleware }>();
 	});
 
 	test("afterNetwork is AfterMiddleware", () => {
 		const result = cacheControl({ cacheControl: "max-age=3600" });
-		expect(result.afterNetwork).type.toBe(
-			/** @type {AfterMiddleware} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(result.afterNetwork).type.toBe<AfterMiddleware>();
 	});
 
 	test("requires cacheControl option", () => {
-		// @ts-expect-error Expected 1 arguments, but got 0.
-		cacheControl();
-		// @ts-expect-error Property 'cacheControl' is missing
-		cacheControl({});
+		expect(cacheControl).type.not.toBeCallableWith();
+		expect(cacheControl).type.not.toBeCallableWith({});
 	});
 });

--- a/packages/core/index.tst.ts
+++ b/packages/core/index.tst.ts
@@ -37,6 +37,8 @@ import {
 	postMessageToFocused,
 	postMethod,
 	putMethod,
+	type RouteConfig,
+	type Strategy,
 	strategyCacheFirst,
 	strategyCacheFirstIgnore,
 	strategyCacheOnly,
@@ -48,352 +50,219 @@ import {
 	strategyStaleWhileRevalidate,
 	strategyStatic,
 	urlRemoveHash,
+	type WorkBeeConfig,
 } from "@work-bee/core";
 import { describe, expect, test } from "tstyche";
 
-/** @typedef {import("@work-bee/core").Strategy} Strategy */
-/** @typedef {import("@work-bee/core").BeforeMiddleware} BeforeMiddleware */
-/** @typedef {import("@work-bee/core").AfterMiddleware} AfterMiddleware */
-/** @typedef {import("@work-bee/core").Middleware} Middleware */
-/** @typedef {import("@work-bee/core").RouteConfig} RouteConfig */
-/** @typedef {import("@work-bee/core").WorkBeeConfig} WorkBeeConfig */
-/** @typedef {import("@work-bee/core").PartitionOptions} PartitionOptions */
-
 describe("types", () => {
 	test("Strategy type", () => {
-		expect(strategyNetworkOnly).type.toBe(
-			/** @type {Strategy} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(strategyNetworkOnly).type.toBe<Strategy>();
 	});
 
 	test("strategies are Strategy type", () => {
-		expect(strategyNetworkOnly).type.toBeAssignableTo(
-			/** @type {Strategy} */ (/** @type {unknown} */ (undefined)),
-		);
-		expect(strategyCacheOnly).type.toBeAssignableTo(
-			/** @type {Strategy} */ (/** @type {unknown} */ (undefined)),
-		);
-		expect(strategyNetworkFirst).type.toBeAssignableTo(
-			/** @type {Strategy} */ (/** @type {unknown} */ (undefined)),
-		);
-		expect(strategyCacheFirst).type.toBeAssignableTo(
-			/** @type {Strategy} */ (/** @type {unknown} */ (undefined)),
-		);
-		expect(strategyStaleWhileRevalidate).type.toBeAssignableTo(
-			/** @type {Strategy} */ (/** @type {unknown} */ (undefined)),
-		);
-		expect(strategyIgnore).type.toBeAssignableTo(
-			/** @type {Strategy} */ (/** @type {unknown} */ (undefined)),
-		);
-		expect(strategyCacheFirstIgnore).type.toBeAssignableTo(
-			/** @type {Strategy} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(strategyNetworkOnly).type.toBeAssignableTo<Strategy>();
+		expect(strategyCacheOnly).type.toBeAssignableTo<Strategy>();
+		expect(strategyNetworkFirst).type.toBeAssignableTo<Strategy>();
+		expect(strategyCacheFirst).type.toBeAssignableTo<Strategy>();
+		expect(strategyStaleWhileRevalidate).type.toBeAssignableTo<Strategy>();
+		expect(strategyIgnore).type.toBeAssignableTo<Strategy>();
+		expect(strategyCacheFirstIgnore).type.toBeAssignableTo<Strategy>();
 	});
 
 	test("strategyStatic returns Strategy", () => {
-		expect(
-			strategyStatic(/** @type {Response} */ (/** @type {unknown} */ ({}))),
-		).type.toBe(/** @type {Strategy} */ (/** @type {unknown} */ (undefined)));
+		expect(strategyStatic({} as Response)).type.toBe<Strategy>();
 	});
 
 	test("strategyHTMLPartition returns Strategy", () => {
-		expect(strategyHTMLPartition()).type.toBe(
-			/** @type {Strategy} */ (/** @type {unknown} */ (undefined)),
-		);
-		expect(strategyHTMLPartition({})).type.toBe(
-			/** @type {Strategy} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(strategyHTMLPartition()).type.toBe<Strategy>();
+		expect(strategyHTMLPartition({})).type.toBe<Strategy>();
 	});
 
 	test("strategyPartition returns Strategy", () => {
-		expect(strategyPartition()).type.toBe(
-			/** @type {Strategy} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(strategyPartition()).type.toBe<Strategy>();
 	});
 });
 
 describe("lib/cache", () => {
 	test("openCaches is Record<string, Cache>", () => {
-		expect(openCaches).type.toBe(
-			/** @type {Record<string, Cache>} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(openCaches).type.toBe<Record<string, Cache>>();
 	});
 
 	test("cacheOverrideEvent returns handler function", () => {
-		expect(
-			cacheOverrideEvent(
-				/** @type {WorkBeeConfig} */ (/** @type {unknown} */ ({})),
-			),
-		).type.toBe(
-			/** @type {(messageEvent: { request: string | Request; response: string | Response }) => Promise<void>} */ (
-				/** @type {unknown} */ (undefined)
-			),
-		);
+		expect(cacheOverrideEvent({} as WorkBeeConfig)).type.toBe<
+			(messageEvent: {
+				request: string | Request;
+				response: string | Response;
+			}) => Promise<void>
+		>();
 	});
 
 	test("cachePut returns Promise<void>", () => {
-		expect(
-			cachePut(
-				"key",
-				/** @type {Request} */ (/** @type {unknown} */ ({})),
-				/** @type {Response} */ (/** @type {unknown} */ ({})),
-			),
-		).type.toBe(
-			/** @type {Promise<void>} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(cachePut("key", {} as Request, {} as Response)).type.toBe<
+			Promise<void>
+		>();
 	});
 
 	test("cacheExpired returns boolean | undefined", () => {
-		expect(
-			cacheExpired(/** @type {Response} */ (/** @type {unknown} */ ({}))),
-		).type.toBe(
-			/** @type {boolean | undefined} */ (/** @type {unknown} */ (undefined)),
-		);
-		expect(cacheExpired(undefined)).type.toBe(
-			/** @type {boolean | undefined} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(cacheExpired({} as Response)).type.toBe<boolean | undefined>();
+		expect(cacheExpired(undefined)).type.toBe<boolean | undefined>();
 	});
 
 	test("cacheDeleteExpired returns Promise<void>", () => {
-		expect(cacheDeleteExpired("key")).type.toBe(
-			/** @type {Promise<void>} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(cacheDeleteExpired("key")).type.toBe<Promise<void>>();
 	});
 
 	test("cachesDeleteExpired returns Promise<undefined[]>", () => {
-		expect(cachesDeleteExpired()).type.toBe(
-			/** @type {Promise<undefined[]>} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(cachesDeleteExpired()).type.toBe<Promise<undefined[]>>();
 	});
 
 	test("cachesDelete returns Promise<boolean[]>", () => {
-		expect(cachesDelete()).type.toBe(
-			/** @type {Promise<boolean[]>} */ (/** @type {unknown} */ (undefined)),
-		);
-		expect(cachesDelete(["exclude"])).type.toBe(
-			/** @type {Promise<boolean[]>} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(cachesDelete()).type.toBe<Promise<boolean[]>>();
+		expect(cachesDelete(["exclude"])).type.toBe<Promise<boolean[]>>();
 	});
 });
 
 describe("lib/config", () => {
 	test("pathPattern returns RegExp", () => {
-		expect(pathPattern("/api/*")).type.toBe(
-			/** @type {RegExp} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(pathPattern("/api/*")).type.toBe<RegExp>();
 	});
 
 	test("defaultConfig is WorkBeeConfig", () => {
-		expect(defaultConfig).type.toBe(
-			/** @type {WorkBeeConfig} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(defaultConfig).type.toBe<WorkBeeConfig>();
 	});
 
 	test("compileConfig returns WorkBeeConfig", () => {
-		expect(compileConfig({})).type.toBe(
-			/** @type {WorkBeeConfig} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(compileConfig({})).type.toBe<WorkBeeConfig>();
 	});
 });
 
 describe("lib/console", () => {
 	test("consoleLog is typeof console.log", () => {
-		expect(consoleLog).type.toBe(
-			/** @type {typeof console.log} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(consoleLog).type.toBe(console.log);
 	});
 
 	test("consoleError is typeof console.error", () => {
-		expect(consoleError).type.toBe(
-			/** @type {typeof console.error} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(consoleError).type.toBe(console.error);
 	});
 });
 
 describe("lib/events", () => {
 	test("eventInstall returns void", () => {
 		expect(
-			eventInstall(
-				/** @type {ExtendableEvent} */ (/** @type {unknown} */ ({})),
-				/** @type {WorkBeeConfig} */ (/** @type {unknown} */ ({})),
-			),
-		).type.toBe(/** @type {void} */ (/** @type {unknown} */ (undefined)));
+			eventInstall({} as ExtendableEvent, {} as WorkBeeConfig),
+		).type.toBe<void>();
 	});
 
 	test("eventActivate returns void", () => {
 		expect(
-			eventActivate(
-				/** @type {ExtendableEvent} */ (/** @type {unknown} */ ({})),
-				/** @type {WorkBeeConfig} */ (/** @type {unknown} */ ({})),
-			),
-		).type.toBe(/** @type {void} */ (/** @type {unknown} */ (undefined)));
+			eventActivate({} as ExtendableEvent, {} as WorkBeeConfig),
+		).type.toBe<void>();
 	});
 
 	test("eventFetch returns void", () => {
-		expect(
-			eventFetch(
-				/** @type {FetchEvent} */ (/** @type {unknown} */ ({})),
-				/** @type {WorkBeeConfig} */ (/** @type {unknown} */ ({})),
-			),
-		).type.toBe(/** @type {void} */ (/** @type {unknown} */ (undefined)));
+		expect(eventFetch({} as FetchEvent, {} as WorkBeeConfig)).type.toBe<void>();
 	});
 
 	test("findRouteConfig returns RouteConfig", () => {
 		expect(
-			findRouteConfig(
-				/** @type {WorkBeeConfig} */ (/** @type {unknown} */ ({})),
-				/** @type {Request} */ (/** @type {unknown} */ ({})),
-			),
-		).type.toBe(
-			/** @type {RouteConfig} */ (/** @type {unknown} */ (undefined)),
-		);
+			findRouteConfig({} as WorkBeeConfig, {} as Request),
+		).type.toBe<RouteConfig>();
 	});
 
 	test("fetchInlineStrategy returns Promise<Response>", () => {
 		expect(
 			fetchInlineStrategy(
-				/** @type {Request} */ (/** @type {unknown} */ ({})),
-				/** @type {ExtendableEvent} */ (/** @type {unknown} */ ({})),
-				/** @type {RouteConfig} */ (/** @type {unknown} */ ({})),
+				{} as Request,
+				{} as ExtendableEvent,
+				{} as RouteConfig,
 			),
-		).type.toBe(
-			/** @type {Promise<Response>} */ (/** @type {unknown} */ (undefined)),
-		);
+		).type.toBe<Promise<Response>>();
 	});
 
 	test("fetchStrategy returns Promise<Response>", () => {
 		expect(
-			fetchStrategy(
-				/** @type {Request} */ (/** @type {unknown} */ ({})),
-				/** @type {ExtendableEvent} */ (/** @type {unknown} */ ({})),
-				/** @type {RouteConfig} */ (/** @type {unknown} */ ({})),
-			),
-		).type.toBe(
-			/** @type {Promise<Response>} */ (/** @type {unknown} */ (undefined)),
-		);
+			fetchStrategy({} as Request, {} as ExtendableEvent, {} as RouteConfig),
+		).type.toBe<Promise<Response>>();
 	});
 });
 
 describe("lib/http", () => {
 	test("headersGetAll returns Record<string, string>", () => {
-		expect(headersGetAll(new Headers())).type.toBe(
-			/** @type {Record<string, string>} */ (
-				/** @type {unknown} */ (undefined)
-			),
-		);
-		expect(headersGetAll(undefined)).type.toBe(
-			/** @type {Record<string, string>} */ (
-				/** @type {unknown} */ (undefined)
-			),
-		);
+		expect(headersGetAll(new Headers())).type.toBe<Record<string, string>>();
+		expect(headersGetAll(undefined)).type.toBe<Record<string, string>>();
 	});
 
 	test("urlRemoveHash returns string", () => {
-		expect(urlRemoveHash("http://example.com#hash")).type.toBe(
-			/** @type {string} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(urlRemoveHash("http://example.com#hash")).type.toBe<string>();
 	});
 
 	test("isRequest is type guard", () => {
-		expect(isRequest(/** @type {unknown} */ (undefined))).type.toBe(
-			/** @type {boolean} */ (/** @type {unknown} */ (undefined)),
-		);
+		const maybeRequest = {};
+
+		if (isRequest(maybeRequest)) {
+			expect(maybeRequest).type.toBe<Request>();
+		}
 	});
 
 	test("newRequest returns Request", () => {
-		expect(newRequest("http://example.com")).type.toBe(
-			/** @type {Request} */ (/** @type {unknown} */ (undefined)),
-		);
-		expect(
-			newRequest(/** @type {Request} */ (/** @type {unknown} */ ({})), {}),
-		).type.toBe(/** @type {Request} */ (/** @type {unknown} */ (undefined)));
+		expect(newRequest("http://example.com")).type.toBe<Request>();
+		expect(newRequest({} as Request, {})).type.toBe<Request>();
 	});
 
 	test("addHeaderToRequest returns Request", () => {
 		expect(
-			addHeaderToRequest(
-				/** @type {Request} */ (/** @type {unknown} */ ({})),
-				"key",
-				"value",
-			),
-		).type.toBe(/** @type {Request} */ (/** @type {unknown} */ (undefined)));
+			addHeaderToRequest({} as Request, "key", "value"),
+		).type.toBe<Request>();
 	});
 
 	test("isResponse is type guard", () => {
-		expect(isResponse(/** @type {unknown} */ (undefined))).type.toBe(
-			/** @type {boolean} */ (/** @type {unknown} */ (undefined)),
-		);
+		const maybeResponse = {};
+
+		if (isResponse(maybeResponse)) {
+			expect(maybeResponse).type.toBe<Response>();
+		}
 	});
 
 	test("newResponse returns Response", () => {
-		expect(newResponse({})).type.toBe(
-			/** @type {Response} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(newResponse({})).type.toBe<Response>();
 		expect(
 			newResponse({ status: 200, url: "http://example.com", body: null }),
-		).type.toBe(/** @type {Response} */ (/** @type {unknown} */ (undefined)));
+		).type.toBe<Response>();
 	});
 
 	test("addHeaderToResponse returns Response", () => {
 		expect(
-			addHeaderToResponse(
-				/** @type {Response} */ (/** @type {unknown} */ ({})),
-				"key",
-				"value",
-			),
-		).type.toBe(/** @type {Response} */ (/** @type {unknown} */ (undefined)));
+			addHeaderToResponse({} as Response, "key", "value"),
+		).type.toBe<Response>();
 	});
 
 	test("deleteHeaderFromResponse returns Response", () => {
 		expect(
-			deleteHeaderFromResponse(
-				/** @type {Response} */ (/** @type {unknown} */ ({})),
-				"key",
-			),
-		).type.toBe(/** @type {Response} */ (/** @type {unknown} */ (undefined)));
+			deleteHeaderFromResponse({} as Response, "key"),
+		).type.toBe<Response>();
 	});
 
 	test("HTTP method constants", () => {
-		expect(getMethod).type.toBe(
-			/** @type {"GET"} */ (/** @type {unknown} */ (undefined)),
-		);
-		expect(postMethod).type.toBe(
-			/** @type {"POST"} */ (/** @type {unknown} */ (undefined)),
-		);
-		expect(putMethod).type.toBe(
-			/** @type {"PUT"} */ (/** @type {unknown} */ (undefined)),
-		);
-		expect(patchMethod).type.toBe(
-			/** @type {"PATCH"} */ (/** @type {unknown} */ (undefined)),
-		);
-		expect(deleteMethod).type.toBe(
-			/** @type {"DELETE"} */ (/** @type {unknown} */ (undefined)),
-		);
-		expect(headMethod).type.toBe(
-			/** @type {"HEAD"} */ (/** @type {unknown} */ (undefined)),
-		);
-		expect(optionsMethod).type.toBe(
-			/** @type {"OPTIONS"} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(getMethod).type.toBe<"GET">();
+		expect(postMethod).type.toBe<"POST">();
+		expect(putMethod).type.toBe<"PUT">();
+		expect(patchMethod).type.toBe<"PATCH">();
+		expect(deleteMethod).type.toBe<"DELETE">();
+		expect(headMethod).type.toBe<"HEAD">();
+		expect(optionsMethod).type.toBe<"OPTIONS">();
 	});
 
 	test("authorizationHeader constant", () => {
-		expect(authorizationHeader).type.toBe(
-			/** @type {"Authorization"} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(authorizationHeader).type.toBe<"Authorization">();
 	});
 });
 
 describe("lib/postMessage", () => {
 	test("postMessageToAll returns Promise<void>", () => {
-		expect(postMessageToAll("msg")).type.toBe(
-			/** @type {Promise<void>} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(postMessageToAll("msg")).type.toBe<Promise<void>>();
 	});
 
 	test("postMessageToFocused returns Promise<void>", () => {
-		expect(postMessageToFocused("msg")).type.toBe(
-			/** @type {Promise<void>} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(postMessageToFocused("msg")).type.toBe<Promise<void>>();
 	});
 });

--- a/packages/fallback/index.tst.ts
+++ b/packages/fallback/index.tst.ts
@@ -1,25 +1,18 @@
 /// <reference lib="webworker" />
 
+import type { AfterMiddleware } from "@work-bee/core";
 import fallback from "@work-bee/fallback";
 import { describe, expect, test } from "tstyche";
-
-/** @typedef {import("@work-bee/core").AfterMiddleware} AfterMiddleware */
 
 describe("fallback", () => {
 	test("returns FallbackMiddlewareResult", () => {
 		const result = fallback({});
-		expect(result).type.toBe(
-			/** @type {{ after: AfterMiddleware }} */ (
-				/** @type {unknown} */ (undefined)
-			),
-		);
+		expect(result).type.toBe<{ after: AfterMiddleware }>();
 	});
 
 	test("after is AfterMiddleware", () => {
 		const result = fallback({});
-		expect(result.after).type.toBe(
-			/** @type {AfterMiddleware} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(result.after).type.toBe<AfterMiddleware>();
 	});
 
 	test("accepts all options", () => {
@@ -28,8 +21,6 @@ describe("fallback", () => {
 			path: "/fallback.html",
 			statusCodes: [404, 500],
 		});
-		expect(result.after).type.toBe(
-			/** @type {AfterMiddleware} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(result.after).type.toBe<AfterMiddleware>();
 	});
 });

--- a/packages/inactivity/index.tst.ts
+++ b/packages/inactivity/index.tst.ts
@@ -1,41 +1,33 @@
 /// <reference lib="webworker" />
 
+import type { AfterMiddleware, BeforeMiddleware } from "@work-bee/core";
 import inactivity from "@work-bee/inactivity";
 import inactivityClient from "@work-bee/inactivity/client";
 import { describe, expect, test } from "tstyche";
 
-/** @typedef {import("@work-bee/core").BeforeMiddleware} BeforeMiddleware */
-/** @typedef {import("@work-bee/core").AfterMiddleware} AfterMiddleware */
-
 describe("inactivity", () => {
 	test("returns InactivityMiddlewareResult", () => {
 		const result = inactivity();
-		expect(result).type.toBe(
-			/** @type {{ before: BeforeMiddleware; after: AfterMiddleware; postMessageEvent: () => void }} */ (
-				/** @type {unknown} */ (undefined)
-			),
-		);
+		expect(result).type.toBe<{
+			before: BeforeMiddleware;
+			after: AfterMiddleware;
+			postMessageEvent: () => void;
+		}>();
 	});
 
 	test("before is BeforeMiddleware", () => {
 		const result = inactivity();
-		expect(result.before).type.toBe(
-			/** @type {BeforeMiddleware} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(result.before).type.toBe<BeforeMiddleware>();
 	});
 
 	test("after is AfterMiddleware", () => {
 		const result = inactivity();
-		expect(result.after).type.toBe(
-			/** @type {AfterMiddleware} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(result.after).type.toBe<AfterMiddleware>();
 	});
 
 	test("postMessageEvent returns void", () => {
 		const result = inactivity();
-		expect(result.postMessageEvent()).type.toBe(
-			/** @type {void} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(result.postMessageEvent()).type.toBe<void>();
 	});
 
 	test("accepts all options", () => {
@@ -46,14 +38,10 @@ describe("inactivity", () => {
 	});
 
 	test("inactivityClient accepts events array", () => {
-		expect(inactivityClient(["click", "keydown"])).type.toBe(
-			/** @type {void} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(inactivityClient(["click", "keydown"])).type.toBe<void>();
 	});
 
 	test("inactivityClient accepts no arguments", () => {
-		expect(inactivityClient()).type.toBe(
-			/** @type {void} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(inactivityClient()).type.toBe<void>();
 	});
 });

--- a/packages/logger/index.tst.ts
+++ b/packages/logger/index.tst.ts
@@ -1,19 +1,18 @@
 /// <reference lib="webworker" />
 
+import type { AfterMiddleware, BeforeMiddleware } from "@work-bee/core";
 import logger from "@work-bee/logger";
 import { describe, expect, test } from "tstyche";
-
-/** @typedef {import("@work-bee/core").BeforeMiddleware} BeforeMiddleware */
-/** @typedef {import("@work-bee/core").AfterMiddleware} AfterMiddleware */
 
 describe("logger", () => {
 	test("returns LoggerMiddlewareResult with defaults", () => {
 		const result = logger();
-		expect(result).type.toBe(
-			/** @type {{ before: BeforeMiddleware | false; beforeNetwork: BeforeMiddleware | false; afterNetwork: AfterMiddleware | false; after: AfterMiddleware | false }} */ (
-				/** @type {unknown} */ (undefined)
-			),
-		);
+		expect(result).type.toBe<{
+			before: BeforeMiddleware | false;
+			beforeNetwork: BeforeMiddleware | false;
+			afterNetwork: AfterMiddleware | false;
+			after: AfterMiddleware | false;
+		}>();
 	});
 
 	test("accepts all options", () => {
@@ -32,10 +31,6 @@ describe("logger", () => {
 			runOnAfterNetwork: true,
 			runOnAfter: false,
 		});
-		expect(result.before).type.toBe(
-			/** @type {BeforeMiddleware | false} */ (
-				/** @type {unknown} */ (undefined)
-			),
-		);
+		expect(result.before).type.toBe<BeforeMiddleware | false>();
 	});
 });

--- a/packages/offline/index.tst.ts
+++ b/packages/offline/index.tst.ts
@@ -1,36 +1,30 @@
 /// <reference lib="webworker" />
 
+import type { AfterMiddleware } from "@work-bee/core";
 import offline, {
 	idbDeserializeRequest,
 	idbSerializeRequest,
+	type SerializedRequest,
 } from "@work-bee/offline";
 import { describe, expect, test } from "tstyche";
-
-/** @typedef {import("@work-bee/core").AfterMiddleware} AfterMiddleware */
-/** @typedef {import("@work-bee/offline").SerializedRequest} SerializedRequest */
 
 describe("offline", () => {
 	test("returns OfflineMiddlewareResult", () => {
 		const result = offline();
-		expect(result).type.toBe(
-			/** @type {{ afterNetwork: AfterMiddleware; postMessageEvent: () => Promise<void> }} */ (
-				/** @type {unknown} */ (undefined)
-			),
-		);
+		expect(result).type.toBe<{
+			afterNetwork: AfterMiddleware;
+			postMessageEvent: () => Promise<void>;
+		}>();
 	});
 
 	test("afterNetwork is AfterMiddleware", () => {
 		const result = offline();
-		expect(result.afterNetwork).type.toBe(
-			/** @type {AfterMiddleware} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(result.afterNetwork).type.toBe<AfterMiddleware>();
 	});
 
 	test("postMessageEvent returns Promise<void>", () => {
 		const result = offline();
-		expect(result.postMessageEvent()).type.toBe(
-			/** @type {Promise<void>} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(result.postMessageEvent()).type.toBe<Promise<void>>();
 	});
 
 	test("accepts all options", () => {
@@ -46,20 +40,12 @@ describe("offline", () => {
 	});
 
 	test("idbSerializeRequest returns Promise<SerializedRequest>", () => {
-		expect(
-			idbSerializeRequest(/** @type {Request} */ (/** @type {unknown} */ ({}))),
-		).type.toBe(
-			/** @type {Promise<SerializedRequest>} */ (
-				/** @type {unknown} */ (undefined)
-			),
-		);
+		expect(idbSerializeRequest({} as Request)).type.toBe<
+			Promise<SerializedRequest>
+		>();
 	});
 
 	test("idbDeserializeRequest returns Request", () => {
-		expect(
-			idbDeserializeRequest(
-				/** @type {SerializedRequest} */ (/** @type {unknown} */ ({})),
-			),
-		).type.toBe(/** @type {Request} */ (/** @type {unknown} */ (undefined)));
+		expect(idbDeserializeRequest({} as SerializedRequest)).type.toBe<Request>();
 	});
 });

--- a/packages/save-data/index.tst.ts
+++ b/packages/save-data/index.tst.ts
@@ -1,40 +1,33 @@
 /// <reference lib="webworker" />
 
+import type {
+	AfterMiddleware,
+	BeforeMiddleware,
+	Strategy,
+} from "@work-bee/core";
 import saveData from "@work-bee/save-data";
 import { describe, expect, test } from "tstyche";
-
-/** @typedef {import("@work-bee/core").BeforeMiddleware} BeforeMiddleware */
-/** @typedef {import("@work-bee/core").AfterMiddleware} AfterMiddleware */
 
 describe("save-data", () => {
 	test("returns SaveDataMiddlewareResult", () => {
 		const result = saveData({});
-		expect(result).type.toBe(
-			/** @type {{ before: BeforeMiddleware; after: AfterMiddleware }} */ (
-				/** @type {unknown} */ (undefined)
-			),
-		);
+		expect(result).type.toBe<{
+			before: BeforeMiddleware;
+			after: AfterMiddleware;
+		}>();
 	});
 
 	test("before is BeforeMiddleware", () => {
 		const result = saveData({});
-		expect(result.before).type.toBe(
-			/** @type {BeforeMiddleware} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(result.before).type.toBe<BeforeMiddleware>();
 	});
 
 	test("after is AfterMiddleware", () => {
 		const result = saveData({});
-		expect(result.after).type.toBe(
-			/** @type {AfterMiddleware} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(result.after).type.toBe<AfterMiddleware>();
 	});
 
 	test("accepts saveDataStrategy option", () => {
-		saveData({
-			saveDataStrategy: /** @type {import("@work-bee/core").Strategy} */ (
-				/** @type {unknown} */ (undefined)
-			),
-		});
+		saveData({ saveDataStrategy: {} as Strategy });
 	});
 });

--- a/packages/session/index.tst.ts
+++ b/packages/session/index.tst.ts
@@ -1,5 +1,6 @@
 /// <reference lib="webworker" />
 
+import type { AfterMiddleware, BeforeMiddleware } from "@work-bee/core";
 import session, {
 	getExpiryJWT,
 	getExpiryPaseto,
@@ -8,29 +9,24 @@ import session, {
 } from "@work-bee/session";
 import { describe, expect, test } from "tstyche";
 
-/** @typedef {import("@work-bee/core").BeforeMiddleware} BeforeMiddleware */
-/** @typedef {import("@work-bee/core").AfterMiddleware} AfterMiddleware */
-
 describe("session", () => {
 	test("returns SessionMiddlewareResult", () => {
 		const result = session({});
-		expect(result).type.toBe(
-			/** @type {{ before?: BeforeMiddleware; afterNetwork?: AfterMiddleware; after?: AfterMiddleware; activityEvent: () => void }} */ (
-				/** @type {unknown} */ (undefined)
-			),
-		);
+		expect(result).type.toBe<{
+			before?: BeforeMiddleware;
+			afterNetwork?: AfterMiddleware;
+			after?: AfterMiddleware;
+			activityEvent: () => void;
+		}>();
 	});
 
 	test("activityEvent returns void", () => {
 		const result = session({});
-		expect(result.activityEvent()).type.toBe(
-			/** @type {void} */ (/** @type {unknown} */ (undefined)),
-		);
+		expect(result.activityEvent()).type.toBe<void>();
 	});
 
 	test("requires opts parameter", () => {
-		// @ts-expect-error Expected 1 arguments, but got 0.
-		session();
+		expect(session).type.not.toBeCallableWith();
 	});
 
 	test("accepts all options", () => {
@@ -48,37 +44,18 @@ describe("session", () => {
 	});
 
 	test("getTokenAuthorization returns string", () => {
-		expect(
-			getTokenAuthorization(
-				/** @type {Response} */ (/** @type {unknown} */ ({})),
-			),
-		).type.toBe(/** @type {string} */ (/** @type {unknown} */ (undefined)));
+		expect(getTokenAuthorization({} as Response)).type.toBe<string>();
 	});
 
 	test("getExpiryJWT returns number", () => {
-		expect(
-			getExpiryJWT(
-				/** @type {Response} */ (/** @type {unknown} */ ({})),
-				"token",
-			),
-		).type.toBe(/** @type {number} */ (/** @type {unknown} */ (undefined)));
+		expect(getExpiryJWT({} as Response, "token")).type.toBe<number>();
 	});
 
 	test("getExpiryPaseto returns number", () => {
-		expect(
-			getExpiryPaseto(
-				/** @type {Response} */ (/** @type {unknown} */ ({})),
-				"token",
-			),
-		).type.toBe(/** @type {number} */ (/** @type {unknown} */ (undefined)));
+		expect(getExpiryPaseto({} as Response, "token")).type.toBe<number>();
 	});
 
 	test("setTokenAuthorization returns Request", () => {
-		expect(
-			setTokenAuthorization(
-				/** @type {Request} */ (/** @type {unknown} */ ({})),
-				"token",
-			),
-		).type.toBe(/** @type {Request} */ (/** @type {unknown} */ (undefined)));
+		expect(setTokenAuthorization({} as Request, "token")).type.toBe<Request>();
 	});
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,0 @@
-{
-	"extends": "@tsconfig/node24"
-}

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,3 +1,0 @@
-{
-	"target": "latest"
-}


### PR DESCRIPTION
This PR updates type tests and adds a CI workflow as well.

I was experimenting with JSDoc comments support in `.js` type test files, but that felt unnecessary verbose. After all, that is only syntax.

At the same time, TSTyche is designed to work well with JavaScript libraries. It is not required to install `typescript` or include `tsconfig.json`. By default, `typescript@latest` is used to test types and strict compiler options are set ([reference](https://tstyche.org/project/compiler-options#default-compiler-options)). I think these are perfect for `workbee` and we can remove `tsconfig.json` (unless you need it for some other tooling).