### PR TITLE
chore: update type tests

### DIFF
--- a/packages/cache-control/index.tst.ts
+++ b/packages/cache-control/index.tst.ts
@@ -7,22 +7,16 @@ import { describe, expect, test } from "tstyche";
 describe("cache-control", () => {
 	test("returns CacheControlMiddlewareResult", () => {
 		const result = cacheControl({ cacheControl: "max-age=3600" });
-		expect(result).type.toBe(
-			undefined as unknown as { afterNetwork: AfterMiddleware },
-		);
+		expect(result).type.toBe<{ afterNetwork: AfterMiddleware }>();
 	});
 
 	test("afterNetwork is AfterMiddleware", () => {
 		const result = cacheControl({ cacheControl: "max-age=3600" });
-		expect(result.afterNetwork).type.toBe(
-			undefined as unknown as AfterMiddleware,
-		);
+		expect(result.afterNetwork).type.toBe<AfterMiddleware>();
 	});
 
 	test("requires cacheControl option", () => {
-		// @ts-expect-error Expected 1 arguments, but got 0.
-		cacheControl();
-		// @ts-expect-error Property 'cacheControl' is missing
-		cacheControl({});
+		expect(cacheControl).type.not.toBeCallableWith();
+		expect(cacheControl).type.not.toBeCallableWith({});
 	});
 });

--- a/packages/core/index.tst.ts
+++ b/packages/core/index.tst.ts
@@ -54,269 +54,213 @@ import { describe, expect, test } from "tstyche";
 
 describe("types", () => {
 	test("Strategy type", () => {
-		expect(strategyNetworkOnly).type.toBe(undefined as unknown as Strategy);
+		expect(strategyNetworkOnly).type.toBe<Strategy>();
 	});
 
 	test("strategies are Strategy type", () => {
-		expect(strategyNetworkOnly).type.toBeAssignableTo(
-			undefined as unknown as Strategy,
-		);
-		expect(strategyCacheOnly).type.toBeAssignableTo(
-			undefined as unknown as Strategy,
-		);
-		expect(strategyNetworkFirst).type.toBeAssignableTo(
-			undefined as unknown as Strategy,
-		);
-		expect(strategyCacheFirst).type.toBeAssignableTo(
-			undefined as unknown as Strategy,
-		);
-		expect(strategyStaleWhileRevalidate).type.toBeAssignableTo(
-			undefined as unknown as Strategy,
-		);
-		expect(strategyIgnore).type.toBeAssignableTo(
-			undefined as unknown as Strategy,
-		);
-		expect(strategyCacheFirstIgnore).type.toBeAssignableTo(
-			undefined as unknown as Strategy,
-		);
+		expect(strategyNetworkOnly).type.toBeAssignableTo<Strategy>();
+		expect(strategyCacheOnly).type.toBeAssignableTo<Strategy>();
+		expect(strategyNetworkFirst).type.toBeAssignableTo<Strategy>();
+		expect(strategyCacheFirst).type.toBeAssignableTo<Strategy>();
+		expect(strategyStaleWhileRevalidate).type.toBeAssignableTo<Strategy>();
+		expect(strategyIgnore).type.toBeAssignableTo<Strategy>();
+		expect(strategyCacheFirstIgnore).type.toBeAssignableTo<Strategy>();
 	});
 
 	test("strategyStatic returns Strategy", () => {
-		expect(strategyStatic({} as unknown as Response)).type.toBe(
-			undefined as unknown as Strategy,
-		);
+		expect(strategyStatic({} as Response)).type.toBe<Strategy>();
 	});
 
 	test("strategyHTMLPartition returns Strategy", () => {
-		expect(strategyHTMLPartition()).type.toBe(undefined as unknown as Strategy);
-		expect(strategyHTMLPartition({})).type.toBe(
-			undefined as unknown as Strategy,
-		);
+		expect(strategyHTMLPartition()).type.toBe<Strategy>();
+		expect(strategyHTMLPartition({})).type.toBe<Strategy>();
 	});
 
 	test("strategyPartition returns Strategy", () => {
-		expect(strategyPartition()).type.toBe(undefined as unknown as Strategy);
+		expect(strategyPartition()).type.toBe<Strategy>();
 	});
 });
 
 describe("lib/cache", () => {
 	test("openCaches is Record<string, Cache>", () => {
-		expect(openCaches).type.toBe(undefined as unknown as Record<string, Cache>);
+		expect(openCaches).type.toBe<Record<string, Cache>>();
 	});
 
 	test("cacheOverrideEvent returns handler function", () => {
-		expect(cacheOverrideEvent({} as unknown as WorkBeeConfig)).type.toBe(
-			undefined as unknown as (messageEvent: {
+		expect(cacheOverrideEvent({} as WorkBeeConfig)).type.toBe<
+			(messageEvent: {
 				request: string | Request;
 				response: string | Response;
-			}) => Promise<void>,
-		);
+			}) => Promise<void>
+		>();
 	});
 
 	test("cachePut returns Promise<void>", () => {
-		expect(
-			cachePut("key", {} as unknown as Request, {} as unknown as Response),
-		).type.toBe(undefined as unknown as Promise<void>);
+		expect(cachePut("key", {} as Request, {} as Response)).type.toBe<
+			Promise<void>
+		>();
 	});
 
 	test("cacheExpired returns boolean | undefined", () => {
-		expect(cacheExpired({} as unknown as Response)).type.toBe(
-			undefined as unknown as boolean | undefined,
-		);
-		expect(cacheExpired(undefined)).type.toBe(
-			undefined as unknown as boolean | undefined,
-		);
+		expect(cacheExpired({} as Response)).type.toBe<boolean | undefined>();
+		expect(cacheExpired(undefined)).type.toBe<boolean | undefined>();
 	});
 
 	test("cacheDeleteExpired returns Promise<void>", () => {
-		expect(cacheDeleteExpired("key")).type.toBe(
-			undefined as unknown as Promise<void>,
-		);
+		expect(cacheDeleteExpired("key")).type.toBe<Promise<void>>();
 	});
 
 	test("cachesDeleteExpired returns Promise<undefined[]>", () => {
-		expect(cachesDeleteExpired()).type.toBe(
-			undefined as unknown as Promise<undefined[]>,
-		);
+		expect(cachesDeleteExpired()).type.toBe<Promise<undefined[]>>();
 	});
 
 	test("cachesDelete returns Promise<boolean[]>", () => {
-		expect(cachesDelete()).type.toBe(
-			undefined as unknown as Promise<boolean[]>,
-		);
-		expect(cachesDelete(["exclude"])).type.toBe(
-			undefined as unknown as Promise<boolean[]>,
-		);
+		expect(cachesDelete()).type.toBe<Promise<boolean[]>>();
+		expect(cachesDelete(["exclude"])).type.toBe<Promise<boolean[]>>();
 	});
 });
 
 describe("lib/config", () => {
 	test("pathPattern returns RegExp", () => {
-		expect(pathPattern("/api/*")).type.toBe(undefined as unknown as RegExp);
+		expect(pathPattern("/api/*")).type.toBe<RegExp>();
 	});
 
 	test("defaultConfig is WorkBeeConfig", () => {
-		expect(defaultConfig).type.toBe(undefined as unknown as WorkBeeConfig);
+		expect(defaultConfig).type.toBe<WorkBeeConfig>();
 	});
 
 	test("compileConfig returns WorkBeeConfig", () => {
-		expect(compileConfig({})).type.toBe(undefined as unknown as WorkBeeConfig);
+		expect(compileConfig({})).type.toBe<WorkBeeConfig>();
 	});
 });
 
 describe("lib/console", () => {
 	test("consoleLog is typeof console.log", () => {
-		expect(consoleLog).type.toBe(undefined as unknown as typeof console.log);
+		expect(consoleLog).type.toBe(console.log);
 	});
 
 	test("consoleError is typeof console.error", () => {
-		expect(consoleError).type.toBe(
-			undefined as unknown as typeof console.error,
-		);
+		expect(consoleError).type.toBe(console.error);
 	});
 });
 
 describe("lib/events", () => {
 	test("eventInstall returns void", () => {
 		expect(
-			eventInstall(
-				{} as unknown as ExtendableEvent,
-				{} as unknown as WorkBeeConfig,
-			),
+			eventInstall({} as ExtendableEvent, {} as WorkBeeConfig),
 		).type.toBe<void>();
 	});
 
 	test("eventActivate returns void", () => {
 		expect(
-			eventActivate(
-				{} as unknown as ExtendableEvent,
-				{} as unknown as WorkBeeConfig,
-			),
+			eventActivate({} as ExtendableEvent, {} as WorkBeeConfig),
 		).type.toBe<void>();
 	});
 
 	test("eventFetch returns void", () => {
-		expect(
-			eventFetch({} as unknown as FetchEvent, {} as unknown as WorkBeeConfig),
-		).type.toBe<void>();
+		expect(eventFetch({} as FetchEvent, {} as WorkBeeConfig)).type.toBe<void>();
 	});
 
 	test("findRouteConfig returns RouteConfig", () => {
 		expect(
-			findRouteConfig({} as unknown as WorkBeeConfig, {} as unknown as Request),
-		).type.toBe(undefined as unknown as RouteConfig);
+			findRouteConfig({} as WorkBeeConfig, {} as Request),
+		).type.toBe<RouteConfig>();
 	});
 
 	test("fetchInlineStrategy returns Promise<Response>", () => {
 		expect(
 			fetchInlineStrategy(
-				{} as unknown as Request,
-				{} as unknown as ExtendableEvent,
-				{} as unknown as RouteConfig,
+				{} as Request,
+				{} as ExtendableEvent,
+				{} as RouteConfig,
 			),
-		).type.toBe(undefined as unknown as Promise<Response>);
+		).type.toBe<Promise<Response>>();
 	});
 
 	test("fetchStrategy returns Promise<Response>", () => {
 		expect(
-			fetchStrategy(
-				{} as unknown as Request,
-				{} as unknown as ExtendableEvent,
-				{} as unknown as RouteConfig,
-			),
-		).type.toBe(undefined as unknown as Promise<Response>);
+			fetchStrategy({} as Request, {} as ExtendableEvent, {} as RouteConfig),
+		).type.toBe<Promise<Response>>();
 	});
 });
 
 describe("lib/http", () => {
 	test("headersGetAll returns Record<string, string>", () => {
-		expect(headersGetAll(new Headers())).type.toBe(
-			undefined as unknown as Record<string, string>,
-		);
-		expect(headersGetAll(undefined)).type.toBe(
-			undefined as unknown as Record<string, string>,
-		);
+		expect(headersGetAll(new Headers())).type.toBe<Record<string, string>>();
+		expect(headersGetAll(undefined)).type.toBe<Record<string, string>>();
 	});
 
 	test("urlRemoveHash returns string", () => {
-		expect(urlRemoveHash("http://example.com#hash")).type.toBe(
-			undefined as unknown as string,
-		);
+		expect(urlRemoveHash("http://example.com#hash")).type.toBe<string>();
 	});
 
 	test("isRequest is type guard", () => {
-		expect(isRequest(undefined as unknown)).type.toBe(
-			undefined as unknown as boolean,
-		);
+		const maybeRequest = {};
+
+		if (isRequest(maybeRequest)) {
+			expect(maybeRequest).type.toBe<Request>();
+		}
 	});
 
 	test("newRequest returns Request", () => {
-		expect(newRequest("http://example.com")).type.toBe(
-			undefined as unknown as Request,
-		);
-		expect(newRequest({} as unknown as Request, {})).type.toBe(
-			undefined as unknown as Request,
-		);
+		expect(newRequest("http://example.com")).type.toBe<Request>();
+		expect(newRequest({} as Request, {})).type.toBe<Request>();
 	});
 
 	test("addHeaderToRequest returns Request", () => {
-		expect(
-			addHeaderToRequest({} as unknown as Request, "key", "value"),
-		).type.toBe(undefined as unknown as Request);
-	});
-
-	test("isResponse is type guard", () => {
-		expect(isResponse(undefined as unknown)).type.toBe(
-			undefined as unknown as boolean,
+		expect(addHeaderToRequest({} as Request, "key", "value")).type.toBe(
+			undefined as unknown as Request,
 		);
 	});
 
+	test("isResponse is type guard", () => {
+		const maybeResponse = {};
+
+		if (isResponse(maybeResponse)) {
+			expect(maybeResponse).type.toBe<Response>();
+		}
+	});
+
 	test("newResponse returns Response", () => {
-		expect(newResponse({})).type.toBe(undefined as unknown as Response);
+		expect(newResponse({})).type.toBe<Response>();
 		expect(
 			newResponse({ status: 200, url: "http://example.com", body: null }),
-		).type.toBe(undefined as unknown as Response);
+		).type.toBe<Response>();
 	});
 
 	test("addHeaderToResponse returns Response", () => {
 		expect(
-			addHeaderToResponse({} as unknown as Response, "key", "value"),
-		).type.toBe(undefined as unknown as Response);
+			addHeaderToResponse({} as Response, "key", "value"),
+		).type.toBe<Response>();
 	});
 
 	test("deleteHeaderFromResponse returns Response", () => {
 		expect(
-			deleteHeaderFromResponse({} as unknown as Response, "key"),
-		).type.toBe(undefined as unknown as Response);
+			deleteHeaderFromResponse({} as Response, "key"),
+		).type.toBe<Response>();
 	});
 
 	test("HTTP method constants", () => {
-		expect(getMethod).type.toBe(undefined as unknown as "GET");
-		expect(postMethod).type.toBe(undefined as unknown as "POST");
-		expect(putMethod).type.toBe(undefined as unknown as "PUT");
-		expect(patchMethod).type.toBe(undefined as unknown as "PATCH");
-		expect(deleteMethod).type.toBe(undefined as unknown as "DELETE");
-		expect(headMethod).type.toBe(undefined as unknown as "HEAD");
-		expect(optionsMethod).type.toBe(undefined as unknown as "OPTIONS");
+		expect(getMethod).type.toBe<"GET">();
+		expect(postMethod).type.toBe<"POST">();
+		expect(putMethod).type.toBe<"PUT">();
+		expect(patchMethod).type.toBe<"PATCH">();
+		expect(deleteMethod).type.toBe<"DELETE">();
+		expect(headMethod).type.toBe<"HEAD">();
+		expect(optionsMethod).type.toBe<"OPTIONS">();
 	});
 
 	test("authorizationHeader constant", () => {
-		expect(authorizationHeader).type.toBe(
-			undefined as unknown as "Authorization",
-		);
+		expect(authorizationHeader).type.toBe<"Authorization">();
 	});
 });
 
 describe("lib/postMessage", () => {
 	test("postMessageToAll returns Promise<void>", () => {
-		expect(postMessageToAll("msg")).type.toBe(
-			undefined as unknown as Promise<void>,
-		);
+		expect(postMessageToAll("msg")).type.toBe<Promise<void>>();
 	});
 
 	test("postMessageToFocused returns Promise<void>", () => {
-		expect(postMessageToFocused("msg")).type.toBe(
-			undefined as unknown as Promise<void>,
-		);
+		expect(postMessageToFocused("msg")).type.toBe<Promise<void>>();
 	});
 });

--- a/packages/fallback/index.tst.ts
+++ b/packages/fallback/index.tst.ts
@@ -7,14 +7,12 @@ import { describe, expect, test } from "tstyche";
 describe("fallback", () => {
 	test("returns FallbackMiddlewareResult", () => {
 		const result = fallback({});
-		expect(result).type.toBe(
-			undefined as unknown as { after: AfterMiddleware },
-		);
+		expect(result).type.toBe<{ after: AfterMiddleware }>();
 	});
 
 	test("after is AfterMiddleware", () => {
 		const result = fallback({});
-		expect(result.after).type.toBe(undefined as unknown as AfterMiddleware);
+		expect(result.after).type.toBe<AfterMiddleware>();
 	});
 
 	test("accepts all options", () => {
@@ -23,6 +21,6 @@ describe("fallback", () => {
 			path: "/fallback.html",
 			statusCodes: [404, 500],
 		});
-		expect(result.after).type.toBe(undefined as unknown as AfterMiddleware);
+		expect(result.after).type.toBe<AfterMiddleware>();
 	});
 });

--- a/packages/inactivity/index.tst.ts
+++ b/packages/inactivity/index.tst.ts
@@ -8,23 +8,21 @@ import { describe, expect, test } from "tstyche";
 describe("inactivity", () => {
 	test("returns InactivityMiddlewareResult", () => {
 		const result = inactivity();
-		expect(result).type.toBe(
-			undefined as unknown as {
-				before: BeforeMiddleware;
-				after: AfterMiddleware;
-				postMessageEvent: () => void;
-			},
-		);
+		expect(result).type.toBe<{
+			before: BeforeMiddleware;
+			after: AfterMiddleware;
+			postMessageEvent: () => void;
+		}>();
 	});
 
 	test("before is BeforeMiddleware", () => {
 		const result = inactivity();
-		expect(result.before).type.toBe(undefined as unknown as BeforeMiddleware);
+		expect(result.before).type.toBe<BeforeMiddleware>();
 	});
 
 	test("after is AfterMiddleware", () => {
 		const result = inactivity();
-		expect(result.after).type.toBe(undefined as unknown as AfterMiddleware);
+		expect(result.after).type.toBe<AfterMiddleware>();
 	});
 
 	test("postMessageEvent returns void", () => {

--- a/packages/logger/index.tst.ts
+++ b/packages/logger/index.tst.ts
@@ -7,14 +7,12 @@ import { describe, expect, test } from "tstyche";
 describe("logger", () => {
 	test("returns LoggerMiddlewareResult with defaults", () => {
 		const result = logger();
-		expect(result).type.toBe(
-			undefined as unknown as {
-				before: BeforeMiddleware | false;
-				beforeNetwork: BeforeMiddleware | false;
-				afterNetwork: AfterMiddleware | false;
-				after: AfterMiddleware | false;
-			},
-		);
+		expect(result).type.toBe<{
+			before: BeforeMiddleware | false;
+			beforeNetwork: BeforeMiddleware | false;
+			afterNetwork: AfterMiddleware | false;
+			after: AfterMiddleware | false;
+		}>();
 	});
 
 	test("accepts all options", () => {
@@ -33,8 +31,6 @@ describe("logger", () => {
 			runOnAfterNetwork: true,
 			runOnAfter: false,
 		});
-		expect(result.before).type.toBe(
-			undefined as unknown as BeforeMiddleware | false,
-		);
+		expect(result.before).type.toBe<BeforeMiddleware | false>();
 	});
 });

--- a/packages/offline/index.tst.ts
+++ b/packages/offline/index.tst.ts
@@ -11,26 +11,20 @@ import { describe, expect, test } from "tstyche";
 describe("offline", () => {
 	test("returns OfflineMiddlewareResult", () => {
 		const result = offline();
-		expect(result).type.toBe(
-			undefined as unknown as {
-				afterNetwork: AfterMiddleware;
-				postMessageEvent: () => Promise<void>;
-			},
-		);
+		expect(result).type.toBe<{
+			afterNetwork: AfterMiddleware;
+			postMessageEvent: () => Promise<void>;
+		}>();
 	});
 
 	test("afterNetwork is AfterMiddleware", () => {
 		const result = offline();
-		expect(result.afterNetwork).type.toBe(
-			undefined as unknown as AfterMiddleware,
-		);
+		expect(result.afterNetwork).type.toBe<AfterMiddleware>();
 	});
 
 	test("postMessageEvent returns Promise<void>", () => {
 		const result = offline();
-		expect(result.postMessageEvent()).type.toBe(
-			undefined as unknown as Promise<void>,
-		);
+		expect(result.postMessageEvent()).type.toBe<Promise<void>>();
 	});
 
 	test("accepts all options", () => {
@@ -46,14 +40,12 @@ describe("offline", () => {
 	});
 
 	test("idbSerializeRequest returns Promise<SerializedRequest>", () => {
-		expect(idbSerializeRequest({} as unknown as Request)).type.toBe(
-			undefined as unknown as Promise<SerializedRequest>,
-		);
+		expect(idbSerializeRequest({} as Request)).type.toBe<
+			Promise<SerializedRequest>
+		>();
 	});
 
 	test("idbDeserializeRequest returns Request", () => {
-		expect(idbDeserializeRequest({} as unknown as SerializedRequest)).type.toBe(
-			undefined as unknown as Request,
-		);
+		expect(idbDeserializeRequest({} as SerializedRequest)).type.toBe<Request>();
 	});
 });

--- a/packages/save-data/index.tst.ts
+++ b/packages/save-data/index.tst.ts
@@ -11,27 +11,23 @@ import { describe, expect, test } from "tstyche";
 describe("save-data", () => {
 	test("returns SaveDataMiddlewareResult", () => {
 		const result = saveData({});
-		expect(result).type.toBe(
-			undefined as unknown as {
-				before: BeforeMiddleware;
-				after: AfterMiddleware;
-			},
-		);
+		expect(result).type.toBe<{
+			before: BeforeMiddleware;
+			after: AfterMiddleware;
+		}>();
 	});
 
 	test("before is BeforeMiddleware", () => {
 		const result = saveData({});
-		expect(result.before).type.toBe(undefined as unknown as BeforeMiddleware);
+		expect(result.before).type.toBe<BeforeMiddleware>();
 	});
 
 	test("after is AfterMiddleware", () => {
 		const result = saveData({});
-		expect(result.after).type.toBe(undefined as unknown as AfterMiddleware);
+		expect(result.after).type.toBe<AfterMiddleware>();
 	});
 
 	test("accepts saveDataStrategy option", () => {
-		saveData({
-			saveDataStrategy: undefined as unknown as Strategy,
-		});
+		saveData({ saveDataStrategy: {} as Strategy });
 	});
 });

--- a/packages/session/index.tst.ts
+++ b/packages/session/index.tst.ts
@@ -12,14 +12,12 @@ import { describe, expect, test } from "tstyche";
 describe("session", () => {
 	test("returns SessionMiddlewareResult", () => {
 		const result = session({});
-		expect(result).type.toBe(
-			undefined as unknown as {
-				before?: BeforeMiddleware;
-				afterNetwork?: AfterMiddleware;
-				after?: AfterMiddleware;
-				activityEvent: () => void;
-			},
-		);
+		expect(result).type.toBe<{
+			before?: BeforeMiddleware;
+			afterNetwork?: AfterMiddleware;
+			after?: AfterMiddleware;
+			activityEvent: () => void;
+		}>();
 	});
 
 	test("activityEvent returns void", () => {
@@ -28,8 +26,7 @@ describe("session", () => {
 	});
 
 	test("requires opts parameter", () => {
-		// @ts-expect-error Expected 1 arguments, but got 0.
-		session();
+		expect(session).type.not.toBeCallableWith();
 	});
 
 	test("accepts all options", () => {
@@ -47,26 +44,18 @@ describe("session", () => {
 	});
 
 	test("getTokenAuthorization returns string", () => {
-		expect(getTokenAuthorization({} as unknown as Response)).type.toBe(
-			undefined as unknown as string,
-		);
+		expect(getTokenAuthorization({} as Response)).type.toBe<string>();
 	});
 
 	test("getExpiryJWT returns number", () => {
-		expect(getExpiryJWT({} as unknown as Response, "token")).type.toBe(
-			undefined as unknown as number,
-		);
+		expect(getExpiryJWT({} as Response, "token")).type.toBe<number>();
 	});
 
 	test("getExpiryPaseto returns number", () => {
-		expect(getExpiryPaseto({} as unknown as Response, "token")).type.toBe(
-			undefined as unknown as number,
-		);
+		expect(getExpiryPaseto({} as Response, "token")).type.toBe<number>();
 	});
 
 	test("setTokenAuthorization returns Request", () => {
-		expect(setTokenAuthorization({} as unknown as Request, "token")).type.toBe(
-			undefined as unknown as Request,
-		);
+		expect(setTokenAuthorization({} as Request, "token")).type.toBe<Request>();
 	});
 });


### PR DESCRIPTION
This PR removes redundant syntax in the type tests. An expression or a type can be passed to assertion on both sides. There is no need for casting or `typeof`. The result is the same.

@willfarrell Hopefully this time I am not too late to the party (;

