### PR TITLE
chore: standardize npm dependabot config with dev/prod groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,5 +13,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      cooldown:
-          default-days: 15
+    cooldown-period: 15
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      prod-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "patch"


### PR DESCRIPTION
## Summary
Apply consistent dependabot npm configuration across repos:

```yaml
  - package-ecosystem: npm
    directory: "/"
    schedule:
      interval: "weekly"
    cooldown-period: 15
    groups:
      dev-dependencies:
        dependency-type: "development"
        update-types:
          - "minor"
          - "patch"
      prod-dependencies:
        dependency-type: "production"
        update-types:
          - "patch"
```

- Group dev dependencies (minor + patch) and prod dependencies (patch only) into batched PRs
- Use `cooldown-period: 15` days consistently (was previously missing, `cooldown-period: 15`, or nested `cooldown: default-days: 15`)

## Test plan
- [ ] Verify dependabot parses config without errors
- [ ] Verify next dependabot run produces grouped `dev-dependencies` / `prod-dependencies` PRs